### PR TITLE
[Hotfix] Rq.getUser 구현 및 Template 엔티티 수정

### DIFF
--- a/src/main/java/com/lgsk/imgreet/entity/Template.java
+++ b/src/main/java/com/lgsk/imgreet/entity/Template.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
@@ -24,6 +25,9 @@ public class Template extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @NotNull
+    private Long creatorId;
 
     @OneToMany(mappedBy = "template", cascade = CascadeType.ALL)
     private List<Bookmark> bookmarks;


### PR DESCRIPTION
<!-- Assignees는 본인, Reviewrs는 팀원 선택 -->

## #️⃣연관된 이슈

> #54 

## 📝작업 내용

>  Rq 클래스 getUser() 메서드를 통해 현재 로그인된 oAuth 계정 정보를 바탕으로 디비에서 조회하여 User entity 객체를 반환하도록 구현하였습니다. 
> 기존에 Template entity 에서 템플릿을 생성한 사용자 정보를 저장할 컬럼이 누락되어 있어 creatorId 필드를 추가해주었습니다.

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
