### PR TITLE
Feature/#73/generate and save share url

### DIFF
--- a/src/main/java/com/lgsk/imgreet/base/commonUtil/JwtUtil.java
+++ b/src/main/java/com/lgsk/imgreet/base/commonUtil/JwtUtil.java
@@ -1,0 +1,31 @@
+package com.lgsk.imgreet.base.commonUtil;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtil {
+
+    private final JwtEncoder jwtEncoder;
+
+    public String generateGreetToken(String greetId) {
+        Instant now = Instant.now();
+        long expiry = 259200L; // 3일
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuer("self")
+                .issuedAt(now)
+                .expiresAt(now.plusSeconds(expiry))
+                .subject(greetId)
+                .claim("scope", "ROLE_USER")
+                .build();
+
+        return jwtEncoder.encode(JwtEncoderParameters.from(claims)).getTokenValue();
+    }
+}

--- a/src/main/java/com/lgsk/imgreet/base/config/SecurityConfig.java
+++ b/src/main/java/com/lgsk/imgreet/base/config/SecurityConfig.java
@@ -1,15 +1,30 @@
 package com.lgsk.imgreet.base.config;
 
 import com.lgsk.imgreet.login.service.OAuthService;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.SecurityContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 @EnableWebSecurity
@@ -18,6 +33,9 @@ public class SecurityConfig {
 
     private final CorsConfig corsConfig;
     private final OAuthService oAuthService;
+
+    @Value("${spring.jwt.secret}")
+    private String SECRET_KEY;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -54,4 +72,20 @@ public class SecurityConfig {
 
         return http.build();
     }
+
+    @Bean
+    public JwtEncoder jwtEncoder() {
+        SecretKey secretKeySpec = new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        JWK jwk = new OctetSequenceKey.Builder(secretKeySpec).build();
+        JWKSource<SecurityContext> jwkSource = new ImmutableJWKSet<>(new JWKSet(jwk));
+
+        return new NimbusJwtEncoder(jwkSource);
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        SecretKeySpec secretKeySpec = new SecretKeySpec(SECRET_KEY.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder.withSecretKey(secretKeySpec).build();
+    }
+
 }

--- a/src/main/java/com/lgsk/imgreet/greet/controller/GreetController.java
+++ b/src/main/java/com/lgsk/imgreet/greet/controller/GreetController.java
@@ -2,17 +2,28 @@ package com.lgsk.imgreet.greet.controller;
 
 import com.lgsk.imgreet.entity.Greet;
 import com.lgsk.imgreet.greet.dto.CreateGreetRequestDTO;
+import com.lgsk.imgreet.greet.dto.GreetResponseDTO;
 import com.lgsk.imgreet.greet.dto.UpdateGreetRequestDTO;
 import com.lgsk.imgreet.greet.service.GreetService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
 
 import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -21,18 +32,58 @@ public class GreetController {
 
     private final GreetService greetService;
 
+    @GetMapping("/share/{token}")
+    public ResponseEntity<String> sharePage(@PathVariable String token, Model model) {
+        Jwt jwt = Jwt.withTokenValue(token).build();
+        Long greetId = (Long) jwt.getClaims().get("greetId");
+        model.addAttribute("greetId", greetId);
+
+        // TODO: remove hard coding
+        String greetUrl = "http://localhost:8080/greet/" + greetId;
+
+        // TODO: RestTemplate DI 적용
+        ResponseEntity<String> responseEntity = new RestTemplate().exchange(
+                greetUrl,
+                HttpMethod.GET,
+                new HttpEntity<>(new HttpHeaders()),
+                String.class
+        );
+
+        return ResponseEntity.status(responseEntity.getStatusCode())
+                .body(responseEntity.getBody());
+    }
+
+    @GetMapping("/greet/share/{id}")
+    public String showGreet(@PathVariable Long id, Model model) {
+        GreetResponseDTO responseDTO = greetService.getGreetById(id);
+        model.addAttribute("greet", responseDTO);
+        return "share";
+    }
+
+    @GetMapping("/greet/myGreet")
+    public ResponseEntity<Object> getMyGreet(@Param("id") Long userId) {
+        List<Greet> greetList = greetService.getGreetByUserId(userId);
+        if (greetList.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(greetList);
+    }
+
     @PostMapping("/greet/draft")
     @PreAuthorize("hasAnyAuthority()")
     public ResponseEntity<Object> temporarySaveGrit(@RequestBody CreateGreetRequestDTO createGreetRequestDTO) {
         Map<String, Object> responseMap = new HashMap<>();
         try {
             Greet greet = greetService.temporarySaveGreet(createGreetRequestDTO);
-            responseMap.put("success", true);
-            responseMap.put("message", "초대장을 성공적으로 임시 저장하였습니다.");
             responseMap.put("greetId", greet.getId());
+            responseMap.put("userId", greet.getUser().getId());
         } catch(Exception e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            responseMap.put("success", false);
+            responseMap.put("message", e.getMessage());
+            return ResponseEntity.badRequest().body(responseMap);
         }
+        responseMap.put("success", true);
+        responseMap.put("message", "초대장을 성공적으로 임시 저장하였습니다.");
         return ResponseEntity.ok(responseMap);
     }
 
@@ -44,7 +95,9 @@ public class GreetController {
             Greet greet = greetService.saveGreet(updateGreetRequestDTO);
             responseMap.put("greetId", greet.getId());
         } catch (UserPrincipalNotFoundException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
+            responseMap.put("success", false);
+            responseMap.put("message", e.getMessage());
+            return ResponseEntity.badRequest().body(responseMap);
         }
         responseMap.put("success", true);
         responseMap.put("message", "초대장을 성공적으로 저장하였습니다.");

--- a/src/main/java/com/lgsk/imgreet/greet/controller/GreetController.java
+++ b/src/main/java/com/lgsk/imgreet/greet/controller/GreetController.java
@@ -39,7 +39,7 @@ public class GreetController {
         model.addAttribute("greetId", greetId);
 
         // TODO: remove hard coding
-        String greetUrl = "http://localhost:8080/greet/" + greetId;
+        String greetUrl = "http://localhost:8080/greet/share" + greetId;
 
         // TODO: RestTemplate DI 적용
         ResponseEntity<String> responseEntity = new RestTemplate().exchange(

--- a/src/main/java/com/lgsk/imgreet/greet/dto/UpdateGreetRequestDTO.java
+++ b/src/main/java/com/lgsk/imgreet/greet/dto/UpdateGreetRequestDTO.java
@@ -3,11 +3,13 @@ package com.lgsk.imgreet.greet.dto;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @Builder
 public class UpdateGreetRequestDTO {
 

--- a/src/main/java/com/lgsk/imgreet/greet/service/GreetService.java
+++ b/src/main/java/com/lgsk/imgreet/greet/service/GreetService.java
@@ -1,5 +1,6 @@
 package com.lgsk.imgreet.greet.service;
 
+import com.lgsk.imgreet.base.commonUtil.JwtUtil;
 import com.lgsk.imgreet.base.commonUtil.Rq;
 import com.lgsk.imgreet.base.entity.Role;
 import com.lgsk.imgreet.entity.Greet;
@@ -15,12 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.naming.LimitExceededException;
 import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class GreetService {
 
     private final GreetRepository greetRepository;
+
+    private final JwtUtil jwtUtil;
 
     private final Rq rq;
 
@@ -30,6 +34,8 @@ public class GreetService {
         if (user == null) {
             throw new UserPrincipalNotFoundException("로그인된 유저 정보가 존재하지 않습니다.");
         }
+        String encodedToken = jwtUtil.generateGreetToken(dto.getId().toString());
+        dto.setUrl("/share/%s".formatted(encodedToken));
         return greetRepository.save(
                 Greet.builder()
                         .id(dto.getId())
@@ -97,5 +103,25 @@ public class GreetService {
 
     private boolean isFreeUser(Role userRole) {
         return !userRole.equals(Role.PAID_USER);
+    }
+
+    @Transactional(readOnly = true)
+    public GreetResponseDTO getGreetById(Long id) {
+        Optional<Greet> greet = greetRepository.findById(id);
+        if(greet.isEmpty()) {
+            throw new RuntimeException("초대장이 존재하지 않습니다.");
+        }
+
+        Greet responseGreet = greet.get();
+
+        return GreetResponseDTO.builder()
+                .id(responseGreet.getId())
+                .user(responseGreet.getUser())
+                .title(responseGreet.getTitle())
+                .url(responseGreet.getUrl())
+                .imageUrl(responseGreet.getImageUrl())
+                .expireDate(responseGreet.getExpireDate())
+                .allowComments(responseGreet.getAllowComments())
+                .build();
     }
 }

--- a/src/main/resources/templates/createGreet.html
+++ b/src/main/resources/templates/createGreet.html
@@ -6,6 +6,8 @@
     <title th:text="${title}">Greet</title>
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=d3ed3db1fc1bdaf63dfdafb12b6475b3&libraries=services"></script>
+    <!--  jQuery  -->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" type="text/css" th:href="@{/css/createGreet.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/text.css}"/>
@@ -32,7 +34,7 @@
                 <a class="nav-link" href="#" id="redoButton">되돌리기</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#" id="shareButton">공유하기</a>
+                <a class="nav-link" id="shareButton">공유하기</a>
             </li>
         </ul>
     </div>
@@ -57,7 +59,6 @@
         <button id="underlineButton"><u>U</u></button>
     </div>
 </div>
-
 
 <div class="fixed-sidebar">
     <div id="categoryButtons">
@@ -120,5 +121,58 @@
 <script src="/js/shapeEditor.js"></script>
 <script src="/js/imageEditor.js"></script>
 <script src="/js/address.js"></script>
+<script>
+    $(document).ready(
+        $('#shareButton').click(function() {
+            if (confirm('초대장을 공유하시겠습니까?')) {
+                temporarySave()
+            }
+        })
+    )
+
+    function temporarySave() {
+        const MILLISECONDS_IN_A_DAY = 24 * 60 * 60 * 1000;
+        const FREE_USER_GREET_EXPIRATION_TIME = 5 * MILLISECONDS_IN_A_DAY;
+
+        $.ajax({
+            url: '/greet/draft',
+            method: 'post',
+            contentType: 'application/json',
+            data: JSON.stringify({
+                title: $('#title').val(),
+                expireDate: new Date($.now() + FREE_USER_GREET_EXPIRATION_TIME),
+                allowComments: false
+            }),
+            success: function(data) {
+                console.log('@@@ data @@@\n' + JSON.stringify(data))
+                shareGreet(data)
+            },
+            error: function(error) {
+                alert(`데이터 저장 실패. ${JSON.stringify(error)}`)
+            }
+        })
+    }
+
+    function shareGreet(data) {
+        $.ajax({
+            url: '/greet/save',
+            method: 'post',
+            contentType: 'application/json',
+            data: {
+                greetId: data.greetId,
+                userId: data.userId,
+                title: $('#title').val(),
+
+
+            },
+            success: function(data) {
+                alert(JSON.stringify(data))
+            },
+            error: function(error) {
+                alert(`공유에 실패하였습니다. ${JSON.stringify(error)}`)
+            }
+        })
+    }
+</script>
 </body>
 </html>


### PR DESCRIPTION
<!-- Assignees는 본인, Reviewrs는 팀원 선택 -->

## #️⃣연관된 이슈

> #73 

## 📝작업 내용

> 초대장 상세 페이지 접근을 위한 엔드포인트 생성
> 초대장 url을 만들 때, greetId 값을 jwt를 활용해 인코딩하여 url을 생성하는 로직 구현
> jwt 관련 bean 생성
> 인코딩을 위한 JwtUtil 클래스 도입
> 토큰을 포함한 엔드포인트로 접근시 토큰을 디코딩하여 초대장 상세 페이지 조회 엔드포인트로 연결 후 페이지를 반환하도록 구현
> 내가 생성한 모든 초대장을 가져오는 엔드포인트 작성
> 초대장 생성 페이지에서 공유하기 버튼 누를 시에, 임시 저장 후 공유 하기를 바로 수행하도록 스크립트 작성(컴포넌트 값 바디에 담아서 보내는 구현 필요)

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

## 체크리스트
